### PR TITLE
String check and replace illegal character '/'

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -23,6 +23,7 @@ module.exports = function(source, target) {
                 '---',
             ];
             var content = item.content['$t'];
+            title = title.replace(new RegExp('/', 'g'), '_');
             fs.writeFile(target + title + '.md', header.join('\n') + '\n\n' + tomd(content), cb);
         }, function(err) {
             if (err) throw err;


### PR DESCRIPTION
<img width="223" alt="2016-01-17 11 05 23" src="https://cloud.githubusercontent.com/assets/4548874/12378112/371238d8-bd6f-11e5-944b-aaa1c7f7c40c.png">

Such titles, "Gawor LDAP Browser/Editor" or "C/C++", are legal in Goggle Blogger. This pull request provides a string check and replace illegal character '/'.
