### PR TITLE
Improve Special Character Handling

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -17,13 +17,13 @@ module.exports = function(source, target) {
                 tags = item.category.map(prop('term'));
             }
             var header = [
-                'title: ' + title,
+                'title: |',
+                '\t' +  title,
                 'date: ' + moment(published).format('YYYY-MM-DD HH:mm:ss'),
                 'tags: [' + tags + ']',
                 '---',
             ];
             var content = item.content['$t'];
-            title = title.replace(new RegExp('/', 'g'), '_');
             fs.writeFile(target + title + '.md', header.join('\n') + '\n\n' + tomd(content), cb);
         }, function(err) {
             if (err) throw err;

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -11,6 +11,7 @@ module.exports = function(source, target) {
         var posts = JSON.parse(body).feed.entry;
         async.each(posts, function(item, cb) {
             var title = item.title['$t'];
+            var file = title.replace(/\s/g,'-').replace(/[^A-z 0-9 -]/g,'');
             var published = item.published['$t'];
             var tags = '';
             if (item.category) {
@@ -24,7 +25,7 @@ module.exports = function(source, target) {
                 '---',
             ];
             var content = item.content['$t'];
-            fs.writeFile(target + title + '.md', header.join('\n') + '\n\n' + tomd(content), cb);
+            fs.writeFile(target + file + '.md', header.join('\n') + '\n\n' + tomd(content), cb);
         }, function(err) {
             if (err) throw err;
             console.log('%d posts migrated.', posts.length);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hexo-migrator-blogger",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Blogger(blogspot.com) migrator plugin for Hexo",
     "main": "index",
     "directories": {


### PR DESCRIPTION
Hi!

I tried to import 2 blogs that contained some characters in the titles that were causing problems.
You can test the import with this: `hexo migrate blogger 'http://blog.meredrica.org/feeds/posts/default?alt=json&max-results=10000'`

it will fail on the Iphone 5C/5S post due to the forward slash.
It will also fail on all posts that contain a `:` in the post title.

I fixed the parsing and bumped the version number. Please merge and publish this.
